### PR TITLE
Avoids high cardinality on metrics

### DIFF
--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -46,7 +46,7 @@ class MetricMiddleware implements MiddlewareInterface
 
             return $response;
         } catch (Throwable $exception) {
-            $this->countException($request);
+            $this->countException($request, $exception);
             $timer->end($labels);
 
             throw $exception;
@@ -65,11 +65,12 @@ class MetricMiddleware implements MiddlewareInterface
         return $dispatched->handler->route;
     }
 
-    protected function countException(ServerRequestInterface $request): void
+    protected function countException(ServerRequestInterface $request, Throwable $exception): void
     {
         $labels = [
             'request_path' => $this->getPath($request),
             'request_method' => $request->getMethod(),
+            'class' => $exception::class,
         ];
 
         Metric::count('exception_count', 1, $labels);

--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -46,7 +46,7 @@ class MetricMiddleware implements MiddlewareInterface
 
             return $response;
         } catch (Throwable $exception) {
-            $this->countException($request, $exception);
+            $this->countException($request);
             $timer->end($labels);
 
             throw $exception;
@@ -65,7 +65,7 @@ class MetricMiddleware implements MiddlewareInterface
         return $dispatched->handler->route;
     }
 
-    protected function countException(ServerRequestInterface $request, Throwable $exception): void
+    protected function countException(ServerRequestInterface $request): void
     {
         $labels = [
             'request_path' => $this->getPath($request),

--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -70,10 +70,6 @@ class MetricMiddleware implements MiddlewareInterface
         $labels = [
             'request_path' => $this->getPath($request),
             'request_method' => $request->getMethod(),
-            'class' => $exception::class,
-            'message' => $exception->getMessage(),
-            'code' => (string) $exception->getCode(),
-            'line' => (string) $exception->getLine(),
         ];
 
         Metric::count('exception_count', 1, $labels);


### PR DESCRIPTION
This kind of labels/dimensions should be on a Span or being used with a proper Exception handler tool like BugSnag. Here they are just increasing the metric cardinality.