### PR TITLE
fix/complying with the psr-4 standard

### DIFF
--- a/tests/Cases/UriTest.php
+++ b/tests/Cases/UriTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @contact  leo@opencodeco.dev
  * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
  */
-namespace HyperfTest\Metric\Support;
+namespace HyperfTest\Metric\Cases;
 
 use Hyperf\Metric\Support\Uri;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
complying with the psr-4 standard **(UriTest)**
Before
```php
/**
 * This file is part of Hyperf + OpenCodeCo
 *
 * @link     https://opencodeco.dev
 * @document https://hyperf.wiki
 * @contact  leo@opencodeco.dev
 * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
 */
namespace HyperfTest\Metric\Support;
```

After
```php
/**
 * This file is part of Hyperf + OpenCodeCo
 *
 * @link     https://opencodeco.dev
 * @document https://hyperf.wiki
 * @contact  leo@opencodeco.dev
 * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
 */
namespace HyperfTest\Metric\Cases;
```