### PR TITLE
Changed: Assumes the root path (/) for urls without declared paths

### DIFF
--- a/src/Aspect/HttpClientMetricAspect.php
+++ b/src/Aspect/HttpClientMetricAspect.php
@@ -45,7 +45,7 @@ class HttpClientMetricAspect implements AroundInterface
         $host = $base_uri === null ? (parse_url($uri, PHP_URL_HOST) ?? '') : $base_uri->getHost();
 
         $labels = [
-            'uri' => SupportUri::sanitize(parse_url($uri, PHP_URL_PATH)),
+            'uri' => SupportUri::sanitize(parse_url($uri, PHP_URL_PATH) ?? '/'),
             'host' => $host,
             'method' => $method,
             'http_status_code' => '200',


### PR DESCRIPTION
### Problem

The following error was preventing events from being sent to bugsnag:
```
[ERROR] Error dispatching exception to Bugsnag: Hyperf\Metric\Support\Uri::sanitize(): Argument #1 ($uri) must be of type string, null given, called in /opt/www/vendor/hyperf/metric/src/Aspect/HttpClientMetricAspect.php on line 48
```

This is because the bugsnag route (`https://notify.bugsnag.com`) does not have a path declared, making the return from the `parse_url` function null.
![image](https://github.com/opencodeco/hyperf-metric/assets/81924557/35a6f2f6-5694-41b9-b2ed-8e025f34c70d)


### Suggested solution
Assumes the root path (/) for urls without declared paths.