### PR TITLE
Feat - add connect exceptions on http client metrics

### DIFF
--- a/src/Aspect/HttpClientMetricAspect.php
+++ b/src/Aspect/HttpClientMetricAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Hyperf\Metric\Aspect;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -22,6 +21,7 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Metric\Support\Uri as SupportUri;
 use Hyperf\Metric\Timer;
 use Hyperf\Stringable\Str;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpClientMetricAspect implements AroundInterface
@@ -77,12 +77,12 @@ class HttpClientMetricAspect implements AroundInterface
 
     private function onRejected(Timer $timer, array $labels): callable
     {
-        return function (RequestException|ConnectException $exception) use ($timer, $labels) {
+        return function (RequestException|NetworkExceptionInterface $exception) use ($timer, $labels) {
             $labels['http_status_code'] = '';
             $labels['message'] = Str::snake($exception->getMessage());
 
             if ($exception instanceof RequestException) {
-                $labels['http_status_code'] = (string)  $exception->getResponse()->getStatusCode();
+                $labels['http_status_code'] = (string) $exception->getResponse()->getStatusCode();
                 $labels['message'] = 'request_exception';
             }
 

--- a/src/Aspect/HttpClientMetricAspect.php
+++ b/src/Aspect/HttpClientMetricAspect.php
@@ -13,6 +13,7 @@ namespace Hyperf\Metric\Aspect;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Uri;
@@ -21,7 +22,6 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Metric\Support\Uri as SupportUri;
 use Hyperf\Metric\Timer;
 use Hyperf\Stringable\Str;
-use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpClientMetricAspect implements AroundInterface
@@ -77,7 +77,7 @@ class HttpClientMetricAspect implements AroundInterface
 
     private function onRejected(Timer $timer, array $labels): callable
     {
-        return function (RequestException|NetworkExceptionInterface $exception) use ($timer, $labels) {
+        return function (TransferException $exception) use ($timer, $labels) {
             $labels['http_status_code'] = '';
             $labels['message'] = Str::snake($exception->getMessage());
 


### PR DESCRIPTION
Catch and add on http client metrics, errors without response code (timeout for example). Today, they are considered as `http_status_code => 200`.


