### PR TITLE
Added: Sql Sanitization

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -19,6 +19,7 @@ use Hyperf\Metric\Aspect\HttpClientMetricAspect;
 use Hyperf\Metric\Aspect\MongoCollectionMetricAspect;
 use Hyperf\Metric\Aspect\RedisMetricAspect;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
+use Hyperf\Metric\Contract\SqlSanitizerInterface;
 use Hyperf\Metric\Listener\DbQueryExecutedMetricListener;
 use Hyperf\Metric\Listener\OnBeforeHandle;
 use Hyperf\Metric\Listener\OnCoroutineServerStart;
@@ -27,6 +28,7 @@ use Hyperf\Metric\Listener\OnPipeMessage;
 use Hyperf\Metric\Listener\OnWorkerStart;
 use Hyperf\Metric\Middleware\MetricMiddleware;
 use Hyperf\Metric\Process\MetricProcess;
+use Hyperf\Metric\Support\SqlSanitizer;
 use InfluxDB\Driver\DriverInterface;
 use InfluxDB\Driver\Guzzle;
 use Prometheus\Storage\Adapter;
@@ -42,6 +44,7 @@ class ConfigProvider
                 Adapter::class => InMemory::class,
                 Connection::class => StatsDConnection::class,
                 DriverInterface::class => Guzzle::class,
+                SqlSanitizerInterface::class => SqlSanitizer::class,
             ],
             'aspects' => [
                 CounterAnnotationAspect::class,

--- a/src/Contract/SqlSanitizerInterface.php
+++ b/src/Contract/SqlSanitizerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf + OpenCodeCo
+ *
+ * @link     https://opencodeco.dev
+ * @document https://hyperf.wiki
+ * @contact  leo@opencodeco.dev
+ * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
+ */
+namespace Hyperf\Metric\Contract;
+
+interface SqlSanitizerInterface
+{
+    public function sanitize(string $sql): string;
+}

--- a/src/Listener/DbQueryExecutedMetricListener.php
+++ b/src/Listener/DbQueryExecutedMetricListener.php
@@ -14,11 +14,16 @@ namespace Hyperf\Metric\Listener;
 use Hyperf\Database\Events\QueryExecuted;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Metric\Contract\MetricFactoryInterface;
+use Hyperf\Metric\Contract\SqlSanitizerInterface;
 
 use function Hyperf\Support\make;
 
 class DbQueryExecutedMetricListener implements ListenerInterface
 {
+    public function __construct(private SqlSanitizerInterface $sqlSanitizer)
+    {
+    }
+
     public function listen(): array
     {
         return [QueryExecuted::class];
@@ -32,7 +37,7 @@ class DbQueryExecutedMetricListener implements ListenerInterface
 
         $labels = [
             'system' => 'mysql',
-            'operation' => $event->sql,
+            'operation' => $this->sqlSanitizer->sanitize($event->sql),
         ];
 
         $histogram = make(MetricFactoryInterface::class)

--- a/src/Support/SqlSanitizer.php
+++ b/src/Support/SqlSanitizer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf + OpenCodeCo
+ *
+ * @link     https://opencodeco.dev
+ * @document https://hyperf.wiki
+ * @contact  leo@opencodeco.dev
+ * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
+ */
+namespace Hyperf\Metric\Support;
+
+use Hyperf\Metric\Contract\SqlSanitizerInterface;
+
+class SqlSanitizer implements SqlSanitizerInterface
+{
+    public function sanitize(string $sql): string
+    {
+        $patterns = [
+            '/(?<=\()\d+(?=\))/',
+            '/(?<=\()\d+(?=,\s)/',
+            '/(?<=,\s)\d+(?=,\s)/',
+            '/(?<=,\s)\d+(?=\))/',
+        ];
+
+        return preg_replace($patterns, array_fill(0, count($patterns), '?'), $sql);
+    }
+}

--- a/tests/Cases/SqlSanitizerTest.php
+++ b/tests/Cases/SqlSanitizerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf + OpenCodeCo
+ *
+ * @link     https://opencodeco.dev
+ * @document https://hyperf.wiki
+ * @contact  leo@opencodeco.dev
+ * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
+ */
+namespace HyperfTest\Metric\Cases;
+
+use Hyperf\Metric\Support\SqlSanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class SqlSanitizerTest extends TestCase
+{
+    public function testSanitizeNumericIds(): void
+    {
+        $sanitizer = new SqlSanitizer();
+
+        self::assertSame(
+            'select * from `users` where `id` in (?)',
+            $sanitizer->sanitize('select * from `users` where `id` in (200093484)')
+        );
+
+        self::assertSame(
+            'select * from `bin_codes` where `bin_codes`.`bin` in (?)',
+            $sanitizer->sanitize('select * from `bin_codes` where `bin_codes`.`bin` in (?)')
+        );
+
+        self::assertSame(
+            'select * from `card_tokens` where (`card_id` = ?)',
+            $sanitizer->sanitize('select * from `card_tokens` where (`card_id` = ?)')
+        );
+
+        self::assertSame(
+            'select * from `cards` where `owner_id` not in (?, ?)',
+            $sanitizer->sanitize('select * from `cards` where `owner_id` not in (1260361, 903023958)')
+        );
+
+        self::assertSame(
+            'select * from `cards` where `owner_id` not in (?, ?, ?)',
+            $sanitizer->sanitize('select * from `cards` where `owner_id` not in (1260361, 903023958, 880427302)')
+        );
+    }
+}


### PR DESCRIPTION
### Problem

When querying using model relationships (hasMany, belongsTo, etc.), the metrics are output without masking the columns values.

> **Current metrics:**

![image](https://github.com/opencodeco/hyperf-metric/assets/81924557/8963be65-f0a7-4185-9bb3-947bae3731ef)

### Suggested solution
The purpose of this change is to mask these values in order to solve cardinality problems.

> **Metrics with sanitization:**

![image](https://github.com/opencodeco/hyperf-metric/assets/81924557/7d095e53-7747-492d-8aae-48bd114401d5)
