### PR TITLE
Ignora URI

### DIFF
--- a/src/Aspect/HttpClientMetricAspect.php
+++ b/src/Aspect/HttpClientMetricAspect.php
@@ -44,9 +44,11 @@ class HttpClientMetricAspect implements AroundInterface
         $method = strtoupper($arguments['keys']['method'] ?? '');
         $uri = $arguments['keys']['uri'] ?? '';
         $host = $base_uri === null ? (parse_url($uri, PHP_URL_HOST) ?? '') : $base_uri->getHost();
-
+        $uri = $this->shouldIgnoreUri($instance)
+            ? '<IGNORED>'
+            : SupportUri::sanitize(parse_url($uri, PHP_URL_PATH) ?? '/');
         $labels = [
-            'uri' => SupportUri::sanitize(parse_url($uri, PHP_URL_PATH) ?? '/'),
+            'uri' => $uri,
             'host' => $host,
             'method' => $method,
             'http_status_code' => '200',
@@ -89,5 +91,10 @@ class HttpClientMetricAspect implements AroundInterface
 
             return Create::rejectionFor($exception);
         };
+    }
+
+    private function shouldIgnoreUri(Client $instance): bool
+    {
+        return $instance->getConfig('ignore_uri') === true;
     }
 }


### PR DESCRIPTION
Adiciona opção para ignorar sanitização/distinção da URI nas métricas, deixando apenas o `host` 


Exemplo:

```php
// config/autoload/guzzle.php

<?php

declare(strict_types=1);

return [
    'card_manager' => [
        'client' => [
            'base_uri' => env('COMMON_PICPAY_CARD_MANAGER_URL'),
            'timeout' => (float)env('TIMEOUT_CARD_MANAGER', 0.5),
            'connect_timeout' => 5,
            'ignore_uri' => true,
        ],
        'pool' => [
            'max_connections' => 10,
        ],
        'retry' => [
            'count' => 1,
            'delay_ms' => 100,
        ],
        'health-check' => false
    ],
];
```
