### PR TITLE
add e2eid uri sanitize

### DIFF
--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  leo@opencodeco.dev
  * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
  */
+
 namespace Hyperf\Metric\Support;
 
 final class Uri
@@ -17,6 +18,7 @@ final class Uri
     {
         return preg_replace(
             [
+                '/\/(?<=\/)[ED]\d{8}\d{12}[0-9a-zA-Z]{11}(?=\/)?/',
                 '/\/(?<=\/)[a-f0-9]{40}(?=\/)?/i',
                 '/\/(?<=\/)([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})(?=\/)?/i',
                 '/\/(?<=\/)([A-Z]{3}-?\d[0-9A-Z]\d{2})(?=\/)?/i',
@@ -24,6 +26,7 @@ final class Uri
                 '/\/(?<=\/)\d+(?=\/)?/',
             ],
             [
+                '/<E2E-ID>',
                 '/<SHA1>',
                 '/<UUID>',
                 '/<LICENSE-PLATE>',

--- a/tests/Cases/UriTest.php
+++ b/tests/Cases/UriTest.php
@@ -118,4 +118,18 @@ final class UriTest extends TestCase
         self::assertSame('/v8/test/<SHA1>/<SHA1>/<SHA1>/', Uri::sanitize('/v8/test/141da78905dcaa7ed8d4da7c3f49a2415ebdc110/141da78905dcaa7ed8d4da7c3f49a2415ebdc110/141da78905dcaa7ed8d4da7c3f49a2415ebdc110/'));
         self::assertSame('/v8/test/<SHA1>/<SHA1>/<SHA1>/', Uri::sanitize('/v8/test/7110EDA4D09E062AA5E4A390B0A572AC0D2C0220/7110EDA4D09E062AA5E4A390B0A572AC0D2C0220/7110EDA4D09E062AA5E4A390B0A572AC0D2C0220/'));
     }
+
+    public function testSanitizeEndToEndId(): void
+    {
+        $e2eid = 'E99999999202401010000abcDEF12345';
+
+        self::assertSame('/v1/test', Uri::sanitize('/v1/test'));
+        self::assertSame('/v2/test/<E2E-ID>', Uri::sanitize("/v2/test/{$e2eid}"));
+        self::assertSame('/v3/test/<E2E-ID>/bar', Uri::sanitize("/v3/test/{$e2eid}/bar"));
+        self::assertSame('/v4/test/<E2E-ID>/bar/<E2E-ID>/', Uri::sanitize("/v4/test/{$e2eid}/bar/{$e2eid}/"));
+        self::assertSame('/v5/test/<E2E-ID>/<E2E-ID>', Uri::sanitize("/v5/test/{$e2eid}/{$e2eid}"));
+        self::assertSame('/v6/test/<E2E-ID>/<E2E-ID>/', Uri::sanitize("/v6/test/{$e2eid}/{$e2eid}/"));
+        self::assertSame('/v7/test/<E2E-ID>/<E2E-ID>/<E2E-ID>', Uri::sanitize("/v7/test/{$e2eid}/{$e2eid}/{$e2eid}"));
+        self::assertSame('/v8/test/<E2E-ID>/<E2E-ID>/<E2E-ID>/', Uri::sanitize("/v8/test/{$e2eid}/{$e2eid}/{$e2eid}/"));
+    }
 }


### PR DESCRIPTION
Problema:
A métrica `http_client_requests` está tendo alta cardinalidade quando a uri possui um `e2eid`.

Sugestão de solução:
Adiciona regex para mascarar o `e2eid` na uri.

![Captura de Tela 2025-03-05 às 13 31 41](https://github.com/user-attachments/assets/3dc4f7ee-c55a-432a-a7d3-676c0f6170ef)
