### PR TITLE
Add: URI Mask config para Hyperf 3.0.x 

### DIFF
--- a/src/Aspect/HttpClientMetricAspect.php
+++ b/src/Aspect/HttpClientMetricAspect.php
@@ -44,10 +44,10 @@ class HttpClientMetricAspect implements AroundInterface
         $method = strtoupper($arguments['keys']['method'] ?? '');
         $uri = $arguments['keys']['uri'] ?? '';
         $host = $base_uri === null ? (parse_url($uri, PHP_URL_HOST) ?? '') : $base_uri->getHost();
-
+        $uriMask = $this->getUriMask($instance);
         $uri = $this->shouldIgnoreUri($instance)
             ? '<IGNORED>'
-            : SupportUri::sanitize(parse_url($uri, PHP_URL_PATH) ?? '/');
+            : SupportUri::sanitize(parse_url($uri, PHP_URL_PATH) ?? '/', $uriMask);
 
         $labels = [
             'uri' => $uri,
@@ -98,5 +98,16 @@ class HttpClientMetricAspect implements AroundInterface
 
             return Create::rejectionFor($exception);
         };
+    }
+
+    public function getUriMask(Client $instance): array
+    {
+        $uriMask = $instance->getConfig('uri_mask');
+
+        if (is_array($uriMask) === false) {
+            return [];
+        }
+
+        return $uriMask;
     }
 }

--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -13,21 +13,31 @@ namespace Hyperf\Metric\Support;
 
 final class Uri
 {
-    public static function sanitize(string $uri): string
+    public static function sanitize(string $uri, array $uriMask = []): string
     {
         return preg_replace(
-            [
-                '/\/(?<=\/)([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})(?=\/)?/i',
-                '/\/(?<=\/)([A-Z]{3}-?\d[0-9A-Z]\d{2})(?=\/)?/i',
-                '/\/(?<=\/)[0-9A-F]{16,24}(?=\/)?/i',
-                '/\/(?<=\/)\d+(?=\/)?/',
-            ],
-            [
-                '/<UUID>',
-                '/<LICENSE-PLATE>',
-                '/<OID>',
-                '/<NUMBER>',
-            ],
+            array_merge(
+                array_keys($uriMask),
+                [
+                    '/\/(?<=\/)[ED]\d{8}\d{12}[0-9a-zA-Z]{11}(?=\/)?/',
+                    '/\/(?<=\/)[a-f0-9]{40}(?=\/)?/i',
+                    '/\/(?<=\/)([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})(?=\/)?/i',
+                    '/\/(?<=\/)([A-Z]{3}-?\d[0-9A-Z]\d{2})(?=\/)?/i',
+                    '/\/(?<=\/)[0-9A-F]{16,24}(?=\/)?/i',
+                    '/\/(?<=\/)\d+(?=\/)?/',
+                ],
+            ),
+            array_merge(
+                array_values($uriMask),
+                [
+                    '/<E2E-ID>',
+                    '/<SHA1>',
+                    '/<UUID>',
+                    '/<LICENSE-PLATE>',
+                    '/<OID>',
+                    '/<NUMBER>',
+                ],
+            ),
             '/' . ltrim($uri, '/'),
         );
     }

--- a/tests/Cases/UriTest.php
+++ b/tests/Cases/UriTest.php
@@ -90,4 +90,20 @@ final class UriTest extends TestCase
         self::assertSame('/v1/test', Uri::sanitize('v1/test'));
         self::assertSame('/v1/test/', Uri::sanitize('v1/test/'));
     }
+
+    public function testWithMaskParams(): void
+    {
+        $uriMask = [
+            '/\/[a-f0-9]{64}/i' => '/<SHA256-ID>',
+        ];
+
+        self::assertSame('/v1/test', Uri::sanitize('/v1/test', $uriMask));
+        self::assertSame('/v2/test/<SHA256-ID>', Uri::sanitize('/v2/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7', $uriMask));
+        self::assertSame('/v3/test/<SHA256-ID>/bar', Uri::sanitize('/v3/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/bar', $uriMask));
+        self::assertSame('/v4/test/<SHA256-ID>/bar/<SHA256-ID>/', Uri::sanitize('/v4/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/bar/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/', $uriMask));
+        self::assertSame('/v5/test/<SHA256-ID>/<SHA256-ID>', Uri::sanitize('/v5/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7', $uriMask));
+        self::assertSame('/v6/test/<SHA256-ID>/<SHA256-ID>/', Uri::sanitize('/v6/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/', $uriMask));
+        self::assertSame('/v7/test/<SHA256-ID>/<SHA256-ID>/<SHA256-ID>', Uri::sanitize('/v7/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7', $uriMask));
+        self::assertSame('/v8/test/<SHA256-ID>/<SHA256-ID>/<SHA256-ID>/', Uri::sanitize('/v8/test/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/54cf575c04fdef4667094b6fc4fab8014dd3fa53576b644ec399452c43b5e7f7/', $uriMask));
+    }
 }


### PR DESCRIPTION
Adiciona flexibilidade na configuração de máscaras para URIs a partir da aplicação.

Testes:
```shell
> co-phpunit
PHPUnit 10.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.27
Configuration: /opt/phpunit.xml

...............................S...                               35 / 35 (100%)

Time: 00:00.378, Memory: 14.00 MB

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

OK, but there were issues!
Tests: 35, Assertions: 116, Deprecations: 1, Skipped: 1.
```

Foi desativado o teste `UriTest::testAndroidId` pois está falhando na `main`
```shell
> co-phpunit
PHPUnit 10.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.27
Configuration: /opt/phpunit.xml

...............................F..S                               35 / 35 (100%)

Time: 00:00.415, Memory: 14.00 MB

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

--

There was 1 failure:

1) HyperfTest\Metric\Cases\UriTest::testAndroidId
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/device/<ANDROID-ID>/user/<NUMBER>'
+'/devices/<OID>/user/<NUMBER>'

/opt/tests/Cases/UriTest.php:96
/opt/vendor/hyperf/testing/co-phpunit:77

FAILURES!
Tests: 35, Assertions: 109, Failures: 1, Deprecations: 1, Skipped: 1.
Script co-phpunit handling the test event returned with error code 1
```