### PR TITLE
Inclui padrão de sanitização para LIMIT e OFFSET no sanitizador de queries SQL

### DIFF
--- a/src/Support/SqlSanitizer.php
+++ b/src/Support/SqlSanitizer.php
@@ -22,6 +22,8 @@ class SqlSanitizer implements SqlSanitizerInterface
             '/(?<=\()\d+(?=,\s)/',
             '/(?<=,\s)\d+(?=,\s)/',
             '/(?<=,\s)\d+(?=\))/',
+            '/(?<=LIMIT\s)\d+/',
+            '/(?<=OFFSET\s)\d+/',
         ];
 
         return preg_replace($patterns, array_fill(0, count($patterns), '?'), $sql);

--- a/tests/Cases/SqlSanitizerTest.php
+++ b/tests/Cases/SqlSanitizerTest.php
@@ -55,13 +55,13 @@ final class SqlSanitizerTest extends TestCase
         $sanitizer = new SqlSanitizer();
 
         self::assertSame(
-            'select * from `cards` where (`user_id` = ?) LIMIT ?',
-            $sanitizer->sanitize('select * from `cards` where (`user_id` = 200093484) LIMIT 100')
+            'select * from `cards` where `user_id` in (?) LIMIT ?',
+            $sanitizer->sanitize('select * from `cards` where `user_id` in (1) LIMIT 100')
         );
 
         self::assertSame(
-            'select * from `cards` where (`user_id` = ?) LIMIT ? OFFSET ?',
-            $sanitizer->sanitize('select * from `cards` where (`user_id` = 200093484) LIMIT 100 OFFSET 100')
+            'select * from `cards` where `user_id` in (?) LIMIT ? OFFSET ?',
+            $sanitizer->sanitize('select * from `cards` where `user_id` in (1) LIMIT 100 OFFSET 100')
         );
     }
 }

--- a/tests/Cases/SqlSanitizerTest.php
+++ b/tests/Cases/SqlSanitizerTest.php
@@ -60,7 +60,7 @@ final class SqlSanitizerTest extends TestCase
         );
 
         self::assertSame(
-            'select * from `cards` where (`user_id` = ?) LIMIT ?',
+            'select * from `cards` where (`user_id` = ?) LIMIT ? OFFSET ?',
             $sanitizer->sanitize('select * from `cards` where (`user_id` = 200093484) LIMIT 100 OFFSET 100')
         );
     }

--- a/tests/Cases/SqlSanitizerTest.php
+++ b/tests/Cases/SqlSanitizerTest.php
@@ -49,4 +49,19 @@ final class SqlSanitizerTest extends TestCase
             $sanitizer->sanitize('select * from `cards` where `owner_id` not in (1260361, 903023958, 880427302)')
         );
     }
+
+    public function testSanitizeLimitAndOffset(): void
+    {
+        $sanitizer = new SqlSanitizer();
+
+        self::assertSame(
+            'select * from `cards` where (`user_id` = ?) LIMIT ?',
+            $sanitizer->sanitize('select * from `cards` where (`user_id` = 200093484) LIMIT 100')
+        );
+
+        self::assertSame(
+            'select * from `cards` where (`user_id` = ?) LIMIT ?',
+            $sanitizer->sanitize('select * from `cards` where (`user_id` = 200093484) LIMIT 100 OFFSET 100')
+        );
+    }
 }


### PR DESCRIPTION
Inclui padrões de sanitização de queries SQL para subsittuir valores de LIMIT e OFFSET, evitando que sejam criadas métricas repetidas sem necessidade.

## Testes:
```sh
/opt/www # composer test
> co-phpunit
PHPUnit 10.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.13
Configuration: /opt/www/phpunit.xml

................................S...                              36 / 36 (100%)

Time: 00:00.477, Memory: 10.00 MB

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

OK, but there were issues!
Tests: 36, Assertions: 118, Deprecations: 1, Skipped: 1.
```